### PR TITLE
Do not override onWindowFocusChanged

### DIFF
--- a/android/KioskActivity.java
+++ b/android/KioskActivity.java
@@ -42,17 +42,17 @@ public class KioskActivity extends CordovaActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         super.init();
-        
+
         if (running) {
             finish(); // prevent more instances of kiosk activity
         }
-        
+
         loadUrl(launchUrl);
-        
+
         // https://github.com/apache/cordova-plugin-statusbar/blob/master/src/android/StatusBar.java
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        
+
         // https://github.com/hkalina/cordova-plugin-kiosk/issues/14
         View decorView = getWindow().getDecorView();
         // Hide the status bar.
@@ -61,7 +61,7 @@ public class KioskActivity extends CordovaActivity {
         // status bar is hidden, so hide that too if necessary.
         ActionBar actionBar = getActionBar();
         if (actionBar != null) actionBar.hide();
-        
+
     }
 
     @Override
@@ -75,42 +75,18 @@ public class KioskActivity extends CordovaActivity {
             ActivityManager activityManager = (ActivityManager) getApplicationContext()
                     .getSystemService(Context.ACTIVITY_SERVICE);
             activityManager.moveTaskToFront(getTaskId(), 0);
-    }     
-    
+    }
+
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         System.out.println("onKeyDown event: keyCode = " + event.getKeyCode());
         return ! allowedKeys.contains(event.getKeyCode()); // prevent event from being propagated if not allowed
     }
-    
+
     @Override
     public void finish() {
         System.out.println("Never finish...");
         // super.finish();
-    }
-
-    // http://www.andreas-schrade.de/2015/02/16/android-tutorial-how-to-create-a-kiosk-mode-in-android/
-    @Override
-    public void onWindowFocusChanged(boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
-        if(!hasFocus) {
-            System.out.println("Focus lost - closing system dialogs");
-            
-            Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
-            sendBroadcast(closeDialog);
-            
-            ActivityManager am = (ActivityManager)getSystemService(Context.ACTIVITY_SERVICE);
-            am.moveTaskToFront(getTaskId(), ActivityManager.MOVE_TASK_WITH_HOME);
-            
-            // sometime required to close opened notification area
-            Timer timer = new Timer();
-            timer.schedule(new TimerTask(){
-                public void run() {
-                    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
-                    sendBroadcast(closeDialog);
-                }
-            }, 500); // 0.5 second
-        }
     }
 }
 


### PR DESCRIPTION
Reason: If not using the kiosk mode, the restarting feature is colossally annoying.
The app keeps restarting, making configuration impossible.

And in kiosk mode, it is unnecessary.
The system takes care of locking down the task.

The aim of this PR is to make the kiosk mode plugin usable and non-intrusive in all use cases.
Ultimately, the goal is to not recompile the app for each customer, but to have one that fits all.